### PR TITLE
Update ğ1-monit link

### DIFF
--- a/content/pages/obtenir-des-g1.md
+++ b/content/pages/obtenir-des-g1.md
@@ -31,6 +31,6 @@ Une fois suffisamment aguerri avec ĞTest, vous pourrez alors tenter de passer �
 
 ### Connaître l'état des demandes
 
-Vous pouvez voir cette file d'attente, et connaître les certifications reçues sur [la page « willMembers »](https://g3.librelois.fr/willMembers?d=65&sort_by=sigCount&order=desc&lg=fr&hideIdtyWithZeroCert=yes&sortSig=Availability). Dans cette page, les membres qui sont le plus en haut ont le plus de chances de devenir membre à plus ou moins court terme.
+Vous pouvez voir cette file d'attente, et connaître les certifications reçues sur [la page « willMembers » de ğ1-monit](https://g1-monit.elois.org/willMembers?lg=fr&hideIdtyWithZeroCert=yes). Dans cette page, les membres qui sont le plus en haut ont le plus de chances de devenir membre à plus ou moins court terme.
 
 Vous pouvez également consulter l'outil [WoTex](http://wotex.cgeek.fr/) pour visualiser les distances entre membres.


### PR DESCRIPTION
change old link g3.librelois.fr by new link g1-monit.elois.org